### PR TITLE
Revert #335 in Eng to reslove GitBook sync issues

### DIFF
--- a/docs/smart-contract/porting-ethereum-contract.md
+++ b/docs/smart-contract/porting-ethereum-contract.md
@@ -1,10 +1,7 @@
 # 이더리움 컨트랙트 포팅 <a id="porting-ethereum-contract"></a>
 
 대부분의 경우 Klaytn에서 이더리움 컨트랙트를 수정 없이 사용할 수 있습니다. 그러나 다음 두 가지 문제에 유의하셔야 합니다.
-{% hint style="success" %}
-NOTE: Baobab 네트워크의 경우 프로토콜 업데이트는 블록번호 `#75373312`번 부터 적용됩니다. Cypress 메인넷의 경우 다음 버전부터 프로토콜 업그레이드가 반영됩니다.
 
-{% endhint %}
 ## 솔리디티 지원 <a id="solidity-support"></a>
 
 Klaytn은 **Istanbul** Ethereum Virtual Machine (EVM)과 공식 호환 가능합니다. 다른 EVM 버전들과의 하위 호환성은 보장되지 않습니다. 따라서 Istanbul 타겟 옵션과 함께 솔리디티 코드를 컴파일하는 것을 권장드립니다. 자세한 내용은 [How to set the EVM version of solc](https://solidity.readthedocs.io/en/latest/using-the-compiler.html#setting-the-evm-version-to-target)를 참고해주세요.


### PR DESCRIPTION
Klaytn v1.7.1 문서 내용이 국문에 반영되지 않았고, 국문/영문 모두 porting-ethereum-contract.md 파일로 인해 GitBook sync err가 발생하였습니다. 현재 두 언어 모두 최신 버전이 노출되지 않아 우선 에러의 원인인 파일만 롤백 후 에러가 해결되는지 확인해볼 예정입니다.

cc @hqjang-pepper @yoomee1313 